### PR TITLE
Snap: Add selfie mirror feature

### DIFF
--- a/res/drawable/ic_settings_selfiemirror.xml
+++ b/res/drawable/ic_settings_selfiemirror.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@color/white"
+        android:pathData="M3 5v14c0 1.1 .89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2H5c-1.11 0-2 .9-2
+2zm12 4c0 1.66-1.34 3-3 3s-3-1.34-3-3 1.34-3 3-3 3 1.34 3 3zm-9 8c0-2 4-3.1
+6-3.1s6 1.1 6 3.1v1H6v-1z" />
+    <path
+        android:pathData="M0 0h24v24H0z" />
+</vector>

--- a/res/values-af/qcomstrings.xml
+++ b/res/values-af/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Selfie Flits</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Rooi oë vermindering</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Selfie-spieël</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Aktiveer</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Deaktiveer</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Outo beligting afbakening</string>
   <!-- High-framerate recording -->

--- a/res/values-ast-rES/qcomstrings.xml
+++ b/res/values-ast-rES/qcomstrings.xml
@@ -82,6 +82,9 @@
   <!-- See More -->
   <!-- Denoise -->
   <string name="pref_camera_denoise_title">Mou reductor de ruiu</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Espeyu d\'autoretratu</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Habilitar</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Deshabilitar</string>
   <!-- ISO -->
   <string name="pref_camera_iso_title">ISO</string>
   <string name="pref_camera_iso_entry_auto">Auto</string>

--- a/res/values-bg/qcomstrings.xml
+++ b/res/values-bg/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Светкавица за селфи</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Намаляване на ефекта червени очи</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Селфи огледало</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Вкл.</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Изкл.</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">AE кадриране</string>
   <!-- High-framerate recording -->

--- a/res/values-ca/qcomstrings.xml
+++ b/res/values-ca/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Selfie flaix</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Reducció d\'ull vermells</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Mirall Selfie</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Activa</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Desactiva</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Bracketing d\'exposició automàtica</string>
   <!-- High-framerate recording -->

--- a/res/values-cs/qcomstrings.xml
+++ b/res/values-cs/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Selfie blesk</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Redukce červených očí</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Selfie zrcadlo</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Povolit</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Zakázat</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Automatický expoziční bracketing</string>
   <!-- High-framerate recording -->

--- a/res/values-da/qcomstrings.xml
+++ b/res/values-da/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Selfie blitz</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Rødøjereduktion</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Selfie-spejl</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Aktivér</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Deaktivér</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Autoeksponeringsrammer</string>
   <!-- High-framerate recording -->

--- a/res/values-de/qcomstrings.xml
+++ b/res/values-de/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Frontblitz</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Rote-Augen-Korrektur</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Selfie-Spiegel</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Aktivieren</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Deaktivieren</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Belichtungsreihe</string>
   <!-- High-framerate recording -->

--- a/res/values-en-rAU/qcomstrings.xml
+++ b/res/values-en-rAU/qcomstrings.xml
@@ -74,6 +74,9 @@
   <!-- The message is shown in dialog when the app encounters an unsupported resolution for Slow motion mode -->
   <!-- The message is shown in toast when the app encounters an unsupported resolution for Stabilization mode -->
   <!-- The message is shown in dialog when the app encounters an unsupported resolution for High speed mode -->
+  <string name="pref_camera_selfiemirror_title" translatable="true">Selfie mirror</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Enable</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Disable</string>
   <!-- The message is shown in dialog when the app encounters an unsupported video codec for HFR mode -->
   <!-- The message is shown in dialog when the app encounters an unsupported video resolution-->
   <!--The message is shown in dialog when the raw snapshot is selected in Zero shutter lag mode-->

--- a/res/values-en-rGB/qcomstrings.xml
+++ b/res/values-en-rGB/qcomstrings.xml
@@ -74,6 +74,9 @@
   <!-- The message is shown in dialog when the app encounters an unsupported resolution for Slow motion mode -->
   <!-- The message is shown in toast when the app encounters an unsupported resolution for Stabilization mode -->
   <!-- The message is shown in dialog when the app encounters an unsupported resolution for High speed mode -->
+  <string name="pref_camera_selfiemirror_title" translatable="true">Selfie mirror</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Enable</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Disable</string>
   <!-- The message is shown in dialog when the app encounters an unsupported video codec for HFR mode -->
   <!-- The message is shown in dialog when the app encounters an unsupported video resolution-->
   <!--The message is shown in dialog when the raw snapshot is selected in Zero shutter lag mode-->

--- a/res/values-en-rIN/qcomstrings.xml
+++ b/res/values-en-rIN/qcomstrings.xml
@@ -74,6 +74,9 @@
   <!-- The message is shown in dialog when the app encounters an unsupported resolution for Slow motion mode -->
   <!-- The message is shown in toast when the app encounters an unsupported resolution for Stabilization mode -->
   <!-- The message is shown in dialog when the app encounters an unsupported resolution for High speed mode -->
+  <string name="pref_camera_selfiemirror_title" translatable="true">Selfie mirror</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Enable</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Disable</string>
   <!-- The message is shown in dialog when the app encounters an unsupported video codec for HFR mode -->
   <!-- The message is shown in dialog when the app encounters an unsupported video resolution-->
   <!--The message is shown in dialog when the raw snapshot is selected in Zero shutter lag mode-->

--- a/res/values-es-rUS/qcomstrings.xml
+++ b/res/values-es-rUS/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Flash para selfie</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Reducción ojos rojos</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Espejo selfie</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Activar</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Desactivar</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">AE bracketing</string>
   <!-- High-framerate recording -->

--- a/res/values-es/qcomstrings.xml
+++ b/res/values-es/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Flash para selfie</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Reducción de ojos rojos</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Espejo Selfie</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Activar</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Desactivar</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Bracketing de exposición automática</string>
   <!-- High-framerate recording -->

--- a/res/values-eu-rES/qcomstrings.xml
+++ b/res/values-eu-rES/qcomstrings.xml
@@ -84,6 +84,9 @@
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Begi gorrien murrizketa</string>
   <!-- AE bracketing -->
+  <string name="pref_camera_selfiemirror_title" translatable="true">Autoargazkietarako ispilua</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Gaitu</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Desgaitu</string>
   <string name="pref_camera_ae_bracket_hdr_title">Esposizio automatikoaren kortxetamendua</string>
   <!-- High-framerate recording -->
   <string name="pref_camera_hfr_title">Abiadura handia/Kamera geldoa</string>

--- a/res/values-fi/qcomstrings.xml
+++ b/res/values-fi/qcomstrings.xml
@@ -83,6 +83,10 @@
   <string name="pref_selfie_flash_title">Etukameran salama</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Punasilmäisyyden vähentäminen</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Selfiepeili</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Ota käyttöön</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Poista käytöstä</string>
+
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Automaattisen valotuksen kiinnitys</string>
   <!-- High-framerate recording -->

--- a/res/values-fr/qcomstrings.xml
+++ b/res/values-fr/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Flash frontal</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Réduction des yeux rouges</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Miroir pour selfie</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Activer</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Désactiver</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Bracketing d\'exposition automatique</string>
   <!-- High-framerate recording -->

--- a/res/values-gl-rES/qcomstrings.xml
+++ b/res/values-gl-rES/qcomstrings.xml
@@ -67,6 +67,9 @@
   <!-- See More -->
   <!-- Denoise -->
   <!-- ISO -->
+  <string name="pref_camera_selfiemirror_title" translatable="true">Espello Selfie</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Activar</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Desactivar</string>
   <string name="pref_camera_iso_entry_iso800">ISO800</string>
   <string name="pref_camera_iso_entry_iso1000">ISO1000</string>
   <string name="pref_camera_iso_entry_iso1200">ISO1200</string>

--- a/res/values-hu/qcomstrings.xml
+++ b/res/values-hu/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Szelfi vaku</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Vörösszem csökkentés</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Tükör-szelfi</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Engedélyezés</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Letiltás</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Automatikus expozíció sorozat</string>
   <!-- High-framerate recording -->

--- a/res/values-in/qcomstrings.xml
+++ b/res/values-in/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Lampu kilat swafoto</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Penurunan mata merah</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Cermin Selfie</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Hidup</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Mati</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Pendekapan Dedahan Automatik</string>
   <!-- High-framerate recording -->

--- a/res/values-it/qcomstrings.xml
+++ b/res/values-it/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Selfie flash</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Riduzione occhi rossi</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Selfie specchiato</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Attiva</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Disattiva</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Auto Exposure Bracketing</string>
   <!-- High-framerate recording -->

--- a/res/values-iw/qcomstrings.xml
+++ b/res/values-iw/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">פלאש סלפי</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">הפחתת עיניים אדומות</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">הפוך סלפי (מראה)</string>
+  <string name="pref_camera_selfiemirror_entry_enable">אפשר</string>
+  <string name="pref_camera_selfiemirror_entry_disable">השבת</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">תיחום חשיפה אוטומטי</string>
   <!-- High-framerate recording -->

--- a/res/values-ja/qcomstrings.xml
+++ b/res/values-ja/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">自撮りフラッシュ</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">赤目軽減</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">自撮りミラー</string>
+  <string name="pref_camera_selfiemirror_entry_enable">有効</string>
+  <string name="pref_camera_selfiemirror_entry_disable">無効</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">自動段階露出</string>
   <!-- High-framerate recording -->

--- a/res/values-ko/qcomstrings.xml
+++ b/res/values-ko/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">셀카 조명</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">적목현상 제거</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">셀카 뒤집기</string>
+  <string name="pref_camera_selfiemirror_entry_enable">사용</string>
+  <string name="pref_camera_selfiemirror_entry_disable">사용 안 함</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">자동 노출 브래킷</string>
   <!-- High-framerate recording -->

--- a/res/values-nb/qcomstrings.xml
+++ b/res/values-nb/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Selfie blits</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Reduksjon av røde øyne</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Selfie speil</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Aktiver</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Deaktiver</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Auto Exposure Bracketing</string>
   <!-- High-framerate recording -->

--- a/res/values-nl/qcomstrings.xml
+++ b/res/values-nl/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Selfie-flits</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Rode ogen verminderen</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Selfie-spiegel</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Inschakelen</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Uitschakelen</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Reeksopname met automatische belichting (AEB)</string>
   <!-- High-framerate recording -->

--- a/res/values-pl/qcomstrings.xml
+++ b/res/values-pl/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Lampa Selfie</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Redukcja czerwonych oczu</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Lusterko</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Włącz</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Wyłącz</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Autobracketing ekspozycji</string>
   <!-- High-framerate recording -->

--- a/res/values-pt-rBR/qcomstrings.xml
+++ b/res/values-pt-rBR/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Selfie flash</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Redução de olhos vermelhos</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Espelhar selfie</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Ativar</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Desativar</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Assistente de auto-exposição</string>
   <!-- High-framerate recording -->

--- a/res/values-pt-rPT/qcomstrings.xml
+++ b/res/values-pt-rPT/qcomstrings.xml
@@ -84,6 +84,9 @@
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Redução de olhos vermelhos</string>
   <!-- AE bracketing -->
+  <string name="pref_camera_selfiemirror_title" translatable="true">Espelhar selfie</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Ativar</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Desativar</string>
   <string name="pref_camera_ae_bracket_hdr_title">Escalonamento de Exposição Automática (AEB)</string>
   <!-- High-framerate recording -->
   <string name="pref_camera_hfr_title">Câmara lenta</string>

--- a/res/values-ro/qcomstrings.xml
+++ b/res/values-ro/qcomstrings.xml
@@ -73,6 +73,9 @@
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Reducerea efectului de ochi roșii</string>
   <!-- AE bracketing -->
+  <string name="pref_camera_selfiemirror_title" translatable="true">Oglindă selfie</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Activați</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Dezactivați</string>
   <!-- High-framerate recording -->
   <string name="pref_camera_hfr_entry_off">Oprit</string>
   <string name="pref_camera_hfr_entry_2x">Mișcare lentă 60 FPS</string>

--- a/res/values-ru/qcomstrings.xml
+++ b/res/values-ru/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Фронт. вспышка</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Устр. эфф. красных глаз</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Селфи-зеркало</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Включить</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Отключить</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Автобрекетинг</string>
   <!-- High-framerate recording -->

--- a/res/values-sk/qcomstrings.xml
+++ b/res/values-sk/qcomstrings.xml
@@ -74,6 +74,9 @@
   <!-- The message is shown in dialog when the app encounters an unsupported resolution for Slow motion mode -->
   <!-- The message is shown in toast when the app encounters an unsupported resolution for Stabilization mode -->
   <!-- The message is shown in dialog when the app encounters an unsupported resolution for High speed mode -->
+  <string name="pref_camera_selfiemirror_title" translatable="true">Selfie zrkadlo</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Zapnúť</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Vypnúť</string>
   <!-- The message is shown in dialog when the app encounters an unsupported video codec for HFR mode -->
   <!-- The message is shown in dialog when the app encounters an unsupported video resolution-->
   <!--The message is shown in dialog when the raw snapshot is selected in Zero shutter lag mode-->

--- a/res/values-sl/qcomstrings.xml
+++ b/res/values-sl/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Bliskavica samoposnetka</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Zmanjšanje učinka rdečih oči</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Ogledalo samoposnetka</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Omogoči</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Onemogoči</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Korektura sam. osvetlitve</string>
   <!-- High-framerate recording -->

--- a/res/values-sq-rAL/qcomstrings.xml
+++ b/res/values-sq-rAL/qcomstrings.xml
@@ -74,6 +74,9 @@
   <!-- The message is shown in dialog when the app encounters an unsupported resolution for Slow motion mode -->
   <!-- The message is shown in toast when the app encounters an unsupported resolution for Stabilization mode -->
   <!-- The message is shown in dialog when the app encounters an unsupported resolution for High speed mode -->
+  <string name="pref_camera_selfiemirror_title" translatable="true">Pasqyra selfie</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Aktivizo</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Çaktivizo</string>
   <!-- The message is shown in dialog when the app encounters an unsupported video codec for HFR mode -->
   <!-- The message is shown in dialog when the app encounters an unsupported video resolution-->
   <!--The message is shown in dialog when the raw snapshot is selected in Zero shutter lag mode-->

--- a/res/values-sr/qcomstrings.xml
+++ b/res/values-sr/qcomstrings.xml
@@ -87,6 +87,9 @@
   <string name="pref_camera_ae_bracket_hdr_title">Држање аутоматске експозиције</string>
   <!-- High-framerate recording -->
   <string name="pref_camera_hfr_title">Успорени снимак</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Огледало за селфи</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Омогући</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Онемогући</string>
   <string name="pref_camera_hfr_entry_off">Искључено</string>
   <string name="pref_camera_hfr_entry_2x">Успорени снимак 60 FPS</string>
   <string name="pref_camera_hfr_entry_3x">Успорени снимак 90 FPS</string>

--- a/res/values-sv/qcomstrings.xml
+++ b/res/values-sv/qcomstrings.xml
@@ -83,6 +83,8 @@
   <string name="pref_selfie_flash_title">Selfie blixt</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Röda ögon-reduktion</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Aktivera</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Avaktivera</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Automatisk exponeringsvariation</string>
   <!-- High-framerate recording -->

--- a/res/values-tr/qcomstrings.xml
+++ b/res/values-tr/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Özçekim flaşı</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Kırmızı göz giderme</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Selfie ayna</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Etkin</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Devre dışı</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">AE braketleme</string>
   <!-- High-framerate recording -->

--- a/res/values-uk/qcomstrings.xml
+++ b/res/values-uk/qcomstrings.xml
@@ -74,6 +74,9 @@
   <!-- The message is shown in dialog when the app encounters an unsupported resolution for Slow motion mode -->
   <!-- The message is shown in toast when the app encounters an unsupported resolution for Stabilization mode -->
   <!-- The message is shown in dialog when the app encounters an unsupported resolution for High speed mode -->
+  <string name="pref_camera_selfiemirror_title" translatable="true">Селфі дзеркало</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Увімкнути</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Вимкнути</string>
   <!-- The message is shown in dialog when the app encounters an unsupported video codec for HFR mode -->
   <!-- The message is shown in dialog when the app encounters an unsupported video resolution-->
   <!--The message is shown in dialog when the raw snapshot is selected in Zero shutter lag mode-->

--- a/res/values-vi/qcomstrings.xml
+++ b/res/values-vi/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">Đèn flash tự sướng</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">Giảm mắt đỏ</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">Gương Selfie</string>
+  <string name="pref_camera_selfiemirror_entry_enable">Bật</string>
+  <string name="pref_camera_selfiemirror_entry_disable">Tắt</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">Chụp liên tục với độ phơi sáng tự động</string>
   <!-- High-framerate recording -->

--- a/res/values-zh-rCN/qcomstrings.xml
+++ b/res/values-zh-rCN/qcomstrings.xml
@@ -83,6 +83,9 @@
   <string name="pref_selfie_flash_title">自拍闪光灯</string>
   <!-- Red eye reduction -->
   <string name="pref_camera_redeyereduction_title">红眼消除</string>
+  <string name="pref_camera_selfiemirror_title" translatable="true">自拍镜</string>
+  <string name="pref_camera_selfiemirror_entry_enable">启用</string>
+  <string name="pref_camera_selfiemirror_entry_disable">禁用</string>
   <!-- AE bracketing -->
   <string name="pref_camera_ae_bracket_hdr_title">自动包围曝光</string>
   <!-- High-framerate recording -->

--- a/res/values-zh-rTW/qcomstrings.xml
+++ b/res/values-zh-rTW/qcomstrings.xml
@@ -74,6 +74,9 @@
   <!-- The message is shown in dialog when the app encounters an unsupported resolution for Slow motion mode -->
   <!-- The message is shown in toast when the app encounters an unsupported resolution for Stabilization mode -->
   <!-- The message is shown in dialog when the app encounters an unsupported resolution for High speed mode -->
+  <string name="pref_camera_selfiemirror_title" translatable="true">自拍鏡</string>
+  <string name="pref_camera_selfiemirror_entry_enable">啟用</string>
+  <string name="pref_camera_selfiemirror_entry_disable">停用</string>
   <!-- The message is shown in dialog when the app encounters an unsupported video codec for HFR mode -->
   <!-- The message is shown in dialog when the app encounters an unsupported video resolution-->
   <!--The message is shown in dialog when the raw snapshot is selected in Zero shutter lag mode-->

--- a/res/values/qcomarrays.xml
+++ b/res/values/qcomarrays.xml
@@ -611,6 +611,15 @@
         <item>enable</item>
     </string-array>
 
+     <string-array name="pref_camera_selfiemirror_entries" translatable="false">
+         <item>@string/pref_camera_selfiemirror_entry_disable</item>
+         <item>@string/pref_camera_selfiemirror_entry_enable</item>
+     </string-array>
+     <string-array name="pref_camera_selfiemirror_entryvalues" translatable="false">
+         <item>disable</item>
+         <item>enable</item>
+     </string-array>
+
     <!-- Autofocus zone -->
     <string-array name="pref_camera_selectablezoneaf_entries" translatable="false">
         <item>@string/pref_camera_selectablezoneaf_entry_auto</item>

--- a/res/values/qcomstrings.xml
+++ b/res/values/qcomstrings.xml
@@ -164,6 +164,11 @@
     <string name="pref_camera_redeyereduction_title">Red eye reduction</string>
     <string name="pref_camera_redeyereduction_default" translatable="false">disable</string>
 
+    <string name="pref_camera_selfiemirror_default" translatable="false">disable</string>
+    <string name="pref_camera_selfiemirror_title" translatable="true">Selfie mirror</string>
+    <string name="pref_camera_selfiemirror_entry_enable">Enable</string>
+    <string name="pref_camera_selfiemirror_entry_disable">Disable</string>
+
     <!-- AE bracketing -->
     <string name="pref_camera_ae_bracket_hdr_title">AE bracketing</string>
     <string name="pref_camera_ae_bracket_hdr_default" translatable="false">Off</string>

--- a/res/xml/camera_preferences.xml
+++ b/res/xml/camera_preferences.xml
@@ -261,6 +261,13 @@
             camera:singleIcon="@drawable/ic_settings_redeye"
             camera:entryValues="@array/pref_camera_redeyereduction_entryvalues" />
     <IconListPreference
+            camera:key="pref_camera_selfiemirror_key"
+            camera:defaultValue="@string/pref_camera_selfiemirror_default"
+            camera:title="@string/pref_camera_selfiemirror_title"
+            camera:entries="@array/pref_camera_selfiemirror_entries"
+            camera:singleIcon="@drawable/ic_settings_selfiemirror"
+            camera:entryValues="@array/pref_camera_selfiemirror_entryvalues" />
+    <IconListPreference
             camera:key="pref_camera_selectablezoneaf_key"
             camera:defaultValue="@string/pref_camera_selectablezoneaf_default"
             camera:title="@string/pref_camera_selectablezoneaf_title"

--- a/src/com/android/camera/CameraSettings.java
+++ b/src/com/android/camera/CameraSettings.java
@@ -102,6 +102,7 @@ public class CameraSettings {
     public static final String KEY_DENOISE = "pref_camera_denoise_key";
     public static final String KEY_BRIGHTNESS = "pref_camera_brightness_key";
     public static final String KEY_REDEYE_REDUCTION = "pref_camera_redeyereduction_key";
+    public static final String KEY_SELFIE_MIRROR = "pref_camera_selfiemirror_key";
     public static final String KEY_CDS_MODE = "pref_camera_cds_mode_key";
     public static final String KEY_VIDEO_CDS_MODE = "pref_camera_video_cds_mode_key";
     public static final String KEY_TNR_MODE = "pref_camera_tnr_mode_key";

--- a/src/com/android/camera/PhotoMenu.java
+++ b/src/com/android/camera/PhotoMenu.java
@@ -158,6 +158,7 @@ public class PhotoMenu extends MenuController
                 CameraSettings.KEY_FOCUS_TIME,
                 CameraSettings.KEY_SHUTTER_SPEED,
                 CameraSettings.KEY_REDEYE_REDUCTION,
+                CameraSettings.KEY_SELFIE_MIRROR,
                 CameraSettings.KEY_POWER_SHUTTER,
                 CameraSettings.KEY_MAX_BRIGHTNESS
         };
@@ -204,7 +205,8 @@ public class PhotoMenu extends MenuController
                 //CameraSettings.KEY_AE_BRACKET_HDR,
                 //CameraSettings.KEY_MANUAL_EXPOSURE,
                 //CameraSettings.KEY_MANUAL_WB,
-                //CameraSettings.KEY_MANUAL_FOCUS
+                //CameraSettings.KEY_MANUAL_FOCUS,
+                CameraSettings.KEY_SELFIE_MIRROR
         };
 
         initSwitchItem(CameraSettings.KEY_CAMERA_ID, mFrontBackSwitcher);

--- a/src/com/android/camera/PhotoModule.java
+++ b/src/com/android/camera/PhotoModule.java
@@ -1989,8 +1989,16 @@ public class PhotoModule
             mUI.overrideSettings(CameraSettings.KEY_FLASH_MODE, flashMode);
         }
 
-        if(mCameraId != CameraHolder.instance().getFrontCameraId())
+        if(mCameraId != CameraHolder.instance().getFrontCameraId()) {
             CameraSettings.removePreferenceFromScreen(mPreferenceGroup, CameraSettings.KEY_SELFIE_FLASH);
+            CameraSettings.removePreferenceFromScreen(mPreferenceGroup, CameraSettings.KEY_SELFIE_MIRROR);
+        } else {
+            ListPreference prefSelfieMirror = mPreferenceGroup.findPreference(CameraSettings.KEY_SELFIE_MIRROR);
+            if(prefSelfieMirror != null && prefSelfieMirror.getValue() != null
+                    && prefSelfieMirror.getValue().equalsIgnoreCase("enable")) {
+                mUI.overrideSettings(CameraSettings.KEY_LONGSHOT, "off");
+            }
+        }
     }
 
     private void overrideCameraSettings(final String flashMode,
@@ -3450,6 +3458,15 @@ public class PhotoModule
 
         mLongShotMaxSnap = SystemProperties.getInt(PERSIST_LONGSHOT_MAX_SNAP, -1);
         mParameters.set("max-longshot-snap",mLongShotMaxSnap);
+
+        // Set selfie mirror
+        String selfieMirror = mPreferences.getString(
+                CameraSettings.KEY_SELFIE_MIRROR,
+                mActivity.getString(R.string.pref_camera_selfiemirror_default));
+        if (selfieMirror.equals("enable"))
+            mParameters.set("snapshot-picture-flip", "flip-h");
+        else
+            mParameters.set("snapshot-picture-flip", "off");
     }
 
     private int estimateJpegFileSize(final Size size, final String quality) {


### PR DESCRIPTION
Pulled translations and drawable from the LineageOS Snap repo.

This implementation of the selfie mirror uses the camera HAL's built-in
flip feature to implement the mirror effect, rather than painfully
performing the mirror effect in Snap directly on the final JPEG.