### PR TITLE
Snap: Fix selfie mirror for OP3(T) camera stack

### DIFF
--- a/src/com/android/camera/PhotoModule.java
+++ b/src/com/android/camera/PhotoModule.java
@@ -3464,7 +3464,7 @@ public class PhotoModule
                 CameraSettings.KEY_SELFIE_MIRROR,
                 mActivity.getString(R.string.pref_camera_selfiemirror_default));
         if (selfieMirror.equals("enable"))
-            mParameters.set("snapshot-picture-flip", "flip-h");
+            mParameters.set("snapshot-picture-flip", "flip-v");
         else
             mParameters.set("snapshot-picture-flip", "off");
     }


### PR DESCRIPTION
For some reason, the flip-h and flip-v features do opposite things on the
OP3(T). flip-h performs a vertical flip, while flip-v performs a horizontal
flip. The selfie mirror needs a horizontal flip, so use flip-v.