### PR TITLE
Snap: Use CountDownLatch to ensure photos get saved when app exits

### DIFF
--- a/src/com/android/camera/CameraActivity.java
+++ b/src/com/android/camera/CameraActivity.java
@@ -118,6 +118,7 @@ import org.codeaurora.snapcam.R;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
 
 import static com.android.camera.CameraManager.CameraOpenErrorCallback;
 import com.android.camera.SDCard;
@@ -1631,13 +1632,12 @@ public class CameraActivity extends Activity
     }
 
     private void waitForImageSave() {
-        long startTime = System.currentTimeMillis();
-        while (mCurrentModule.delayAppExitToSaveImage()) {
-            SystemClock.sleep(20);
-            long timeNow = System.currentTimeMillis();
-            if ((timeNow - startTime) > 5000) {
-                Log.e(TAG, "Couldn't save photo! Timed out after trying for 5000ms");
-                break;
+        CountDownLatch latch = mCurrentModule.getCaptureCountDownLatch();
+        if (latch != null) {
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Log.e(TAG, "Interrupted exception! Couldn't save photo.");
             }
         }
     }

--- a/src/com/android/camera/CameraModule.java
+++ b/src/com/android/camera/CameraModule.java
@@ -20,6 +20,7 @@ import android.content.Intent;
 import android.content.res.Configuration;
 import android.view.KeyEvent;
 import android.view.View;
+import java.util.concurrent.CountDownLatch;
 
 public interface CameraModule {
 
@@ -71,5 +72,5 @@ public interface CameraModule {
 
     public void onSwitchSavePath();
 
-    public boolean delayAppExitToSaveImage();
+    public CountDownLatch getCaptureCountDownLatch();
 }

--- a/src/com/android/camera/PhotoModule.java
+++ b/src/com/android/camera/PhotoModule.java
@@ -97,6 +97,7 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Vector;
 import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
 import android.util.AttributeSet;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -317,7 +318,6 @@ public class PhotoModule
     private long mJpegPictureCallbackTime;
     private long mOnResumeTime;
     private byte[] mJpegImageData;
-    private boolean mWaitForJpegCallback;
 
     // These latency time are for the CameraLatency test.
     public long mAutoFocusTime;
@@ -336,6 +336,7 @@ public class PhotoModule
     private final Handler mHandler = new MainHandler();
     private MessageQueue.IdleHandler mIdleHandler = null;
     private HandlerThread mCaptureHandlerThread;
+    private CountDownLatch mCaptureCountDownLatch;
 
     private PreferenceGroup mPreferenceGroup;
 
@@ -840,8 +841,8 @@ public class PhotoModule
     }
 
     @Override
-    public boolean delayAppExitToSaveImage() {
-        return mWaitForJpegCallback;
+    public CountDownLatch getCaptureCountDownLatch() {
+        return mCaptureCountDownLatch;
     }
 
     private void keepMediaProviderInstance() {
@@ -1232,6 +1233,7 @@ public class PhotoModule
                 });
             }
             if (mPaused) {
+                mCaptureCountDownLatch.countDown();
                 return;
             }
             if (mIsImageCaptureIntent) {
@@ -1511,7 +1513,7 @@ public class PhotoModule
                 }
             }
 
-            mWaitForJpegCallback = false;
+            mCaptureCountDownLatch.countDown();
         }
     }
 
@@ -1636,7 +1638,6 @@ public class PhotoModule
         mCaptureStartTime = System.currentTimeMillis();
         mPostViewPictureCallbackTime = 0;
         mJpegImageData = null;
-        mWaitForJpegCallback = true;
 
         final boolean animateBefore = (mSceneMode == CameraUtil.SCENE_MODE_HDR);
         if(mHistogramEnabled) {
@@ -1729,6 +1730,7 @@ public class PhotoModule
             }
         } else {
             Handler handler = new Handler(mCaptureHandlerThread.getLooper());
+            mCaptureCountDownLatch = new CountDownLatch(1);
             mCameraDevice.enableShutterSound(!mRefocus);
             mCameraDevice.takePicture(handler,
                     new ShutterCallback(!animateBefore),

--- a/src/com/android/camera/VideoModule.java
+++ b/src/com/android/camera/VideoModule.java
@@ -75,6 +75,7 @@ import com.android.camera.PhotoModule;
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.util.concurrent.CountDownLatch;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
@@ -1107,8 +1108,8 @@ public class VideoModule implements CameraModule,
     }
 
     @Override
-    public boolean delayAppExitToSaveImage() {
-        return false;
+    public CountDownLatch getCaptureCountDownLatch() {
+        return null;
     }
 
     @Override

--- a/src/com/android/camera/WideAnglePanoramaModule.java
+++ b/src/com/android/camera/WideAnglePanoramaModule.java
@@ -60,6 +60,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.TimeZone;
+import java.util.concurrent.CountDownLatch;
 
 /**
  * Activity to handle panorama capturing.
@@ -954,8 +955,8 @@ public class WideAnglePanoramaModule
     }
 
     @Override
-    public boolean delayAppExitToSaveImage() {
-        return false;
+    public CountDownLatch getCaptureCountDownLatch() {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
This is much cleaner than a loop with frequent sleeps. This fixes photos
not getting saved when it takes longer than 5000ms to save them (such as
when the device is in low-power mode).